### PR TITLE
Enable collection mount syntax and accessing route params from template

### DIFF
--- a/src/Http/Controllers/BonusController.php
+++ b/src/Http/Controllers/BonusController.php
@@ -31,6 +31,10 @@ class BonusController extends Controller
 
         $url = $this->resolveEntryUrl($collection, $params);
 
+        if ($collection->mount()) {
+            $params['mount'] = $collection;
+        }
+
         if ($url === false) {
             return $this->response($params, $collection);
         }
@@ -75,7 +79,7 @@ class BonusController extends Controller
         return app(View::class)
             ->template($params['view'] ?? $data['template'] ?? $template)
             ->layout($data['layout'] ?? $layout)
-            ->with($params['data'] ?? [])
+            ->with(array_merge(array_except($params, 'data'), $params['data'] ?? []))
             ->cascadeContent($content);
     }
 


### PR DESCRIPTION
This PR does two things:
1. Enable collection "mount syntax" - https://statamic.dev/collections#looping-through-mounted-entries
Basically all that is needed is a variable called `mount` that contains the collection.


2. Accessing route params from the template.
Using the example from the readme, this route:
```php
Route::bonus('collection:blog', '{mount}/{year}', 'blog.archive');
```

would cause the parameter `year` to be accessible from the template.  Which could make for easier filtering like so:
```
{{ collection :from="mount" date:ends_with=" {year}" }}
```