### PR TITLE
Allow collections without mount entry

### DIFF
--- a/src/Http/Controllers/BonusController.php
+++ b/src/Http/Controllers/BonusController.php
@@ -93,7 +93,7 @@ class BonusController extends Controller
 
     protected function resolveEntryUrl($collection, $params)
     {
-        $params['mount'] = $collection->mount()->url();
+        $params['mount'] = optional($collection->mount())->url();
 
         $format = $collection->routes()->get('default');
 

--- a/src/Mixins/Router.php
+++ b/src/Mixins/Router.php
@@ -37,7 +37,7 @@ class Router
                 if (! $collection) {
                     return $this;
                 }
-                $uri = $resolveMountUri($uri, $collection->mount()->url());
+                $uri = $resolveMountUri($uri, optional($collection->mount())->url());
             } else if ($mode === 'taxonomy') {
                 $taxonomy = Taxonomy::findByHandle($handle);
                 if (! $taxonomy) {


### PR DESCRIPTION
I'm creating bonus routes for a generic `pages` collection that doesn't have a mount entry defined. This PR adds support for collections without mount entries by wrapping the calls in `optional()`.